### PR TITLE
#7 Brat fixed for new `NE` and `Relation`

### DIFF
--- a/plugins/visualizations/nlp_brat/json2json.lsd
+++ b/plugins/visualizations/nlp_brat/json2json.lsd
@@ -73,7 +73,7 @@ bratdsl = """{
     if (isNer) {
            targetEntities += lastViewAnns.select{ %.has(&."@type", "NamedEntity")}
            .unique{ &.start + " " + &.end }.foreach {
-                            [&.id, %.toUpper(&."label"), [[&.start.toInteger(), &.end.toInteger()]]]
+                            [&.id, %.toUpper(&.features.category), [[&.start.toInteger(), &.end.toInteger()]]]
            }
     }
 

--- a/plugins/visualizations/nlp_brat/json2json.lsd
+++ b/plugins/visualizations/nlp_brat/json2json.lsd
@@ -43,6 +43,7 @@ bratdsl = """{
     def isNer = %.has(lastView.metadata.contains,  "NamedEntity")
     def isTagger = %.has(lastView.metadata.contains,  "Token#pos")
     def isRelation = %.has(lastView.metadata.contains,  "Relation")
+    def isEvent = %.has(lastView.metadata.contains,  "Event")
 
     def lastViewAnns = lastView.annotations
     if (lastViewAnns == null) return
@@ -76,6 +77,15 @@ bratdsl = """{
                             [&.id, %.toUpper(&.features.category), [[&.start.toInteger(), &.end.toInteger()]]]
            }
     }
+
+    if (isEvent) {
+           targetEntities += lastViewAnns.select{ %.has(&."@type", "Event")}
+           .unique{ &.start + " " + &.end }.foreach {
+                    def label = it.features.containsKey('type') ? it.features.type : it.features.class
+                            [&.id, label, [[&.start.toInteger(), &.end.toInteger()]]]
+           }
+    }
+
 
     if (isRelation) {
         targetRelations = lastViewAnns.select{%.has(&."@type", "Relation")}.foreach {

--- a/plugins/visualizations/nlp_brat/json2json.lsd
+++ b/plugins/visualizations/nlp_brat/json2json.lsd
@@ -42,6 +42,7 @@ bratdsl = """{
     def isParser = %.has(lastView.metadata.contains,  "Constituent")
     def isNer = %.has(lastView.metadata.contains,  "NamedEntity")
     def isTagger = %.has(lastView.metadata.contains,  "Token#pos")
+    def isRelation = %.has(lastView.metadata.contains,  "Relation")
 
     def lastViewAnns = lastView.annotations
     if (lastViewAnns == null) return
@@ -74,6 +75,13 @@ bratdsl = """{
            .unique{ &.start + " " + &.end }.foreach {
                             [&.id, %.toUpper(&."label"), [[&.start.toInteger(), &.end.toInteger()]]]
            }
+    }
+
+    if (isRelation) {
+        targetRelations = lastViewAnns.select{%.has(&."@type", "Relation")}.foreach {
+            def arguments = &.features.findAll{it.key != "pred"}.collect{[it.key, it.value]}
+            return [&.id, %.toUpper(&.label), arguments]
+        }
     }
 
     //if (isTagger) {

--- a/plugins/visualizations/nlp_brat/json2json.lsd
+++ b/plugins/visualizations/nlp_brat/json2json.lsd
@@ -70,8 +70,9 @@ bratdsl = """{
     }
 
     if (isNer) {
-           targetEntities += lastViewAnns.select{ %.hasAny(&."@type", "Date", "Person", "Location", "Organization" )}.unique{ &.start + " " + &.end }.foreach {
-                [&.id, %.toUpper(%.lastWord(&."@type")), [[&.start.toInteger(), &.end.toInteger()]]]
+           targetEntities += lastViewAnns.select{ %.has(&."@type", "NamedEntity")}
+           .unique{ &.start + " " + &.end }.foreach {
+                            [&.id, %.toUpper(&."label"), [[&.start.toInteger(), &.end.toInteger()]]]
            }
     }
 

--- a/plugins/visualizations/nlp_brat/templates/nlp_brat.mako
+++ b/plugins/visualizations/nlp_brat/templates/nlp_brat.mako
@@ -7,7 +7,7 @@ reload(sys);
 sys.setdefaultencoding('utf8')
 lappsjson = hda.get_raw_data()
 lappsjsonfil = hda.dataset.file_name
-lsdpath = os.path.join(os.getcwd(),'config/plugins/visualizations/nlp_brat/json2json.lsd')
+lsdpath = os.path.join(os.getcwd(),'../mods/plugins/visualizations/nlp_brat/json2json.lsd')
 bratjson = """{
     "text" : "Unknown Text ..."
 }"""


### PR DESCRIPTION
This addresses #7 .

* For `NamedEntity`,  the values of`"label"` field are used as label in the brat 
    * This will break Brandeis services, until lappsgrid-services/edu.brandeis.cs.stanfordnlp-web-service#10 and lappsgrid-services/edu.brandeis.cs.opennlp-web-service#8 are fixed. 
    * dkpro wrapper would be fixed later with other bugfixes 
* For `Relation` the values of `"label"` field are used as label for the relation itself, and everything in `"features"` except for `features.pred` will be seen as arguments, presumably only two exist. 
    * This will work with both representation suggested from the discussion in #7 .